### PR TITLE
[MOD] set output path into each dataset name

### DIFF
--- a/replica.sh
+++ b/replica.sh
@@ -55,7 +55,7 @@ run_()
     echo "run $dataset"
     python -W ignore gs_icp_slam.py --dataset_path $DATASET_PATH/$dataset\
                                     --config $config\
-                                    --output_path $OUTPUT_PATH\
+                                    --output_path $OUTPUT_PATH/$dataset/results\
                                     --keyframe_th $keyframe_th\
                                     --knn_maxd $knn_maxd\
                                     --overlapped_th $overlapped_th\


### PR DESCRIPTION
The existing output path is structured in a way that it continuously overwrites files in a single folder. However, the bash file processes multiple datasets from the replica, such as room and office, at once. As a result, since the current setup overwrites the previous data while processing multiple datasets, the data is not properly saved. Therefore, this is a new bash file that resolves the issue.